### PR TITLE
Add benchmark for a JSON parser

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -26,3 +26,11 @@ pest_typed_generator.workspace = true
 pest_typed.workspace = true
 indoc = { version = "2.0" }
 anyhow = { version = "1.0" }
+criterion = "0.5.1"
+pest = "2.7.5"
+pest_derive = "2.7.5"
+
+
+[[bench]]
+name = "basic_benchmark"
+harness = false

--- a/derive/benches/basic_benchmark.rs
+++ b/derive/benches/basic_benchmark.rs
@@ -1,0 +1,42 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use pest::Parser;
+use pest_typed::ParsableTypedNode;
+
+pub mod json_typed {
+    use pest_typed_derive::TypedParser;
+    //
+    #[derive(TypedParser)]
+    #[grammar = "benches/json.pest"]
+    #[emit_rule_reference]
+    pub struct JsonParser;
+}
+
+pub mod json_pest {
+    use pest_derive::Parser;
+    //
+    #[derive(Parser)]
+    #[grammar = "benches/json.pest"]
+    pub struct JsonParser;
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sample-size-example");
+    group.sample_size(10);
+    group.bench_function("json_typed", |b| {
+        b.iter(|| {
+            let json_file =
+                include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/benches/Canada.json"));
+            let _ = json_typed::pairs::json::try_parse(json_file);
+        })
+    });
+    group.bench_function("json_pest", |b| {
+        b.iter(|| {
+            let json_file =
+                include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/benches/Canada.json"));
+            let pairs = json_pest::JsonParser::parse(json_pest::Rule::json, json_file).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/derive/benches/json.pest
+++ b/derive/benches/json.pest
@@ -1,0 +1,41 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+// 
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+//! A parser for JSON file.
+//!
+//! And this is a example for JSON parser.
+json = { SOI ~ value ~ EOI }
+
+/// Matches object, e.g.: `{ "foo": "bar" }`
+/// Foobar
+object = { "{" ~ pair ~ ("," ~ pair)* ~ "}" | "{" ~ "}" }
+pair   = { #key = string ~ ":" ~ #val = value }
+
+array = { "[" ~ value ~ ("," ~ value)* ~ "]" | "[" ~ "]" }
+
+// //////////////////////
+// /// Matches value, e.g.: `"foo"`, `42`, `true`, `null`, `[]`, `{}`.
+// //////////////////////
+
+value = { string | number | object | array | bool | null }
+
+string  = @{ "\"" ~ inner ~ "\"" }
+inner   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ inner)? }
+escape  = @{ "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | unicode) }
+unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
+
+number = @{ "-"? ~ int ~ ("." ~ ASCII_DIGIT+ ~ exp? | exp)? }
+int    = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+exp    = @{ ("E" | "e") ~ ("+" | "-")? ~ ASCII_DIGIT+ }
+
+bool = { "true" | "false" }
+
+null = { "null" }
+
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }


### PR DESCRIPTION
### What it does
Adds a benchmark

### Background
I just tried pest-typed a bit and was interested in the performance. So I added a little benchmark I took from [Geal/pestvsnom](https://github.com/Geal/pestvsnom).

I get about 300 seconds for parsing as opposed to 100 milliseconds for pest.

Can you reproduce this behaviour?